### PR TITLE
Support for boolean comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,10 @@ COMP_STMT             --> KEY == VALUE | KEY != VALUE
 KEY                   --> IDENTIFIER INDEX? (.IDENTIFIER INDEX?)*
 INDEX                 --> [NUMBER]
 IDENTIFIER            --> LETTER+
-VALUE                 --> STRING | NUMBER
+VALUE                 --> STRING | NUMBER | BOOLEAN
 STRING                --> "CHARS_LIMITED"
 NUMBER                --> DIGIT+
+BOOLEAN               --> true | false
 CHARS                 --> ({UNICODE}\{COM_LINE_IDEN, COM_BLOCK_IDEN_OPEN})*
 CHARS_LIMITED         --> (LETTER* DIGIT* SCHAR*)*
 LETTER                --> a|b|...|y|z|A|B|...|Y|Z

--- a/compiler/cpp/CMakeLists.txt
+++ b/compiler/cpp/CMakeLists.txt
@@ -48,6 +48,8 @@ add_executable(compiler
         src/parser/ast/ContentExprAST.h
         src/parser/ast/ArbitraryExprAST.cpp
         src/parser/ast/ArbitraryExprAST.h
+        src/parser/ast/BooleanExprAST.cpp
+        src/parser/ast/BooleanExprAST.h
         src/analyzer/analyzer.cpp
         src/analyzer/analyzer.h
         src/interpreter/interpreter.cpp

--- a/compiler/cpp/src/analyzer/analyzer.cpp
+++ b/compiler/cpp/src/analyzer/analyzer.cpp
@@ -68,6 +68,9 @@ void checkDataTypeCompatibilityCompStmt(CompStmtExprAST* compStmt, const json& d
     if (dynamic_cast<StringExprAST*>(compStmt->GetValue().get())) {
         if (!jsonKeyValue.is_string())
             throw std::runtime_error(jsonKeyValue.dump() + " is not a string");
+    } else if (dynamic_cast<BooleanExprAST*>(compStmt->GetValue().get())) {
+        if (!jsonKeyValue.is_boolean())
+            throw std::runtime_error(jsonKeyValue.dump() + " is not a boolean");
     } else {
         if (!jsonKeyValue.is_number_integer())
             throw std::runtime_error(jsonKeyValue.dump() + " is not an integer");

--- a/compiler/cpp/src/analyzer/analyzer.h
+++ b/compiler/cpp/src/analyzer/analyzer.h
@@ -4,8 +4,7 @@
 // Created by Marc on 11.05.2021.
 //
 
-#ifndef COMPILER_ANALYZER_H
-#define COMPILER_ANALYZER_H
+#pragma once
 
 #include <nlohmann/json.hpp>
 #include "../parser/ast/ExprAST.h"
@@ -22,5 +21,3 @@ void checkDataTypeCompatibility(bool, ExprAST*, const json&);
 void checkDataTypeCompatibilityContent(ExprAST*, const json&);
 void checkDataTypeCompatibilityStmtList(ExprAST*, const json&);
 void checkDataTypeCompatibilityCompStmt(CompStmtExprAST*, const json&);
-
-#endif //COMPILER_ANALYZER_H

--- a/compiler/cpp/src/interpreter/interpreter.cpp
+++ b/compiler/cpp/src/interpreter/interpreter.cpp
@@ -92,11 +92,18 @@ bool evaluateCompStatement(CompStmtExprAST* ast, const json& data) {
     json keyValue = getJsonValueFromKey(ast->GetKey(), data);
     if (keyValue.is_string()) {
         auto value = keyValue.get<std::string>();
-        if (auto* expectedValue = dynamic_cast<StringExprAST*>(ast->GetValue().get())) {
+        if (auto *expectedValue = dynamic_cast<StringExprAST*>(ast->GetValue().get())) {
             return value == expectedValue->GetValue();
         }
         // This should never get triggered, because invalid type combinations are already filtered out
         throw std::runtime_error("Internal compiler error - JSON value was string and hardcoded was not");
+    } else if (keyValue.is_boolean()) {
+        auto value = keyValue.get<bool>();
+        if (auto *expectedValue = dynamic_cast<BooleanExprAST*>(ast->GetValue().get())) {
+            return value == expectedValue->GetValue();
+        }
+        // This should never get triggered, because invalid type combinations are already filtered out
+        throw std::runtime_error("Internal compiler error - JSON value was boolean and hardcoded was not");
     } else if (keyValue.is_number_integer()) {
         auto value = keyValue.get<int>();
         if (auto* expectedValue = dynamic_cast<NumberExprAST*>(ast->GetValue().get())) {

--- a/compiler/cpp/src/interpreter/interpreter.h
+++ b/compiler/cpp/src/interpreter/interpreter.h
@@ -4,8 +4,7 @@
 // Created by Marc on 14.05.2021.
 //
 
-#ifndef COMPILER_INTERPRETER_H
-#define COMPILER_INTERPRETER_H
+#pragma once
 
 #include <string>
 #include "../parser/ast/ExprAST.h"
@@ -23,5 +22,3 @@ std::string getOutputOfRelevantSection(SectionExprAST*, const json&);
 bool evaluateStmtList(ExprAST *ast, const json &data);
 bool evaluateHasStatement(HasStmtExprAST*, const json&);
 bool evaluateCompStatement(CompStmtExprAST*, const json&);
-
-#endif //COMPILER_INTERPRETER_H

--- a/compiler/cpp/src/lexer/Token.h
+++ b/compiler/cpp/src/lexer/Token.h
@@ -4,8 +4,7 @@
 // Created by Marc on 02.05.2021.
 //
 
-#ifndef COMPILER_TOKEN_H
-#define COMPILER_TOKEN_H
+#pragma once
 
 #include <string>
 
@@ -23,5 +22,3 @@ public:
     std::string getValue();
     std::string getCodePos();
 };
-
-#endif //COMPILER_TOKEN_H

--- a/compiler/cpp/src/lexer/lexer.h
+++ b/compiler/cpp/src/lexer/lexer.h
@@ -4,8 +4,7 @@
 // Created by Marc on 02.05.2021.
 //
 
-#ifndef COMPILER_LEXER_H
-#define COMPILER_LEXER_H
+#pragma once
 
 #include <string>
 #include <stdexcept>
@@ -90,5 +89,3 @@ bool isLookaheadBlockCommentCharClose();
 bool isLookaheadBlockCommentCharCloseWithBrace();
 
 void initLexer(bool, const std::string&, const std::string&, const std::string&, const std::string&);
-
-#endif //COMPILER_LEXER_H

--- a/compiler/cpp/src/main.h
+++ b/compiler/cpp/src/main.h
@@ -4,13 +4,10 @@
 // Created by Marc on 02.05.2021.
 //
 
-#ifndef COMPILER_MAIN_H
-#define COMPILER_MAIN_H
+#pragma once
 
 #include <iostream>
 #include <vector>
 #include "interpreter/interpreter.h"
 
 int main(int, char**);
-
-#endif //COMPILER_MAIN_H

--- a/compiler/cpp/src/parser/ast/ArbitraryExprAST.h
+++ b/compiler/cpp/src/parser/ast/ArbitraryExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 09.05.2021.
 //
 
-#ifndef COMPILER_ARBITRARYEXPRAST_H
-#define COMPILER_ARBITRARYEXPRAST_H
+#pragma once
 
 #include <string>
 #include <utility>
@@ -18,5 +17,3 @@ public:
     explicit ArbitraryExprAST(std::string value): Value(std::move(value)) {}
     std::string GetValue() const;
 };
-
-#endif //COMPILER_ARBITRARYEXPRAST_H

--- a/compiler/cpp/src/parser/ast/BooleanExprAST.cpp
+++ b/compiler/cpp/src/parser/ast/BooleanExprAST.cpp
@@ -1,0 +1,9 @@
+//
+// Created by Marc on 20.05.2021.
+//
+
+#include "BooleanExprAST.h"
+
+bool BooleanExprAST::GetValue() const {
+    return Value;
+}

--- a/compiler/cpp/src/parser/ast/BooleanExprAST.h
+++ b/compiler/cpp/src/parser/ast/BooleanExprAST.h
@@ -1,0 +1,18 @@
+//
+// Created by Marc on 20.05.2021.
+//
+
+#ifndef COMPILER_BOOLEANEXPRAST_H
+#define COMPILER_BOOLEANEXPRAST_H
+
+#include "ValueExprAST.h"
+
+class BooleanExprAST : public ValueExprAST {
+private:
+    bool Value;
+public:
+    explicit BooleanExprAST(bool val): Value(val) {}
+    bool GetValue() const;
+};
+
+#endif //COMPILER_BOOLEANEXPRAST_H

--- a/compiler/cpp/src/parser/ast/BooleanExprAST.h
+++ b/compiler/cpp/src/parser/ast/BooleanExprAST.h
@@ -2,8 +2,7 @@
 // Created by Marc on 20.05.2021.
 //
 
-#ifndef COMPILER_BOOLEANEXPRAST_H
-#define COMPILER_BOOLEANEXPRAST_H
+#pragma once
 
 #include "ValueExprAST.h"
 
@@ -14,5 +13,3 @@ public:
     explicit BooleanExprAST(bool val): Value(val) {}
     bool GetValue() const;
 };
-
-#endif //COMPILER_BOOLEANEXPRAST_H

--- a/compiler/cpp/src/parser/ast/ComBlockBlockExprAST.h
+++ b/compiler/cpp/src/parser/ast/ComBlockBlockExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 09.05.2021.
 //
 
-#ifndef COMPILER_COMBLOCKBLOCKEXPRAST_H
-#define COMPILER_COMBLOCKBLOCKEXPRAST_H
+#pragma once
 
 #include <memory>
 #include "IfBlockExprAST.h"
@@ -18,5 +17,3 @@ public:
     explicit ComBlockBlockExprAST(std::unique_ptr<IfBlockExprAST> ifBlock): IfBlock(std::move(ifBlock)) {}
     const std::unique_ptr<IfBlockExprAST> &GetIfBlock();
 };
-
-#endif //COMPILER_COMBLOCKBLOCKEXPRAST_H

--- a/compiler/cpp/src/parser/ast/ComBlockExprAST.h
+++ b/compiler/cpp/src/parser/ast/ComBlockExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 09.05.2021.
 //
 
-#ifndef COMPILER_COMBLOCKEXPRAST_H
-#define COMPILER_COMBLOCKEXPRAST_H
+#pragma once
 
 #include "ExprAST.h"
 
@@ -13,5 +12,3 @@ class ComBlockExprAST : public ExprAST {
 public:
     ~ComBlockExprAST() override = default;
 };
-
-#endif //COMPILER_COMBLOCKEXPRAST_H

--- a/compiler/cpp/src/parser/ast/ComLineBlockExprAST.h
+++ b/compiler/cpp/src/parser/ast/ComLineBlockExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 09.05.2021.
 //
 
-#ifndef COMPILER_COMLINEBLOCKEXPRAST_H
-#define COMPILER_COMLINEBLOCKEXPRAST_H
+#pragma once
 
 #include <memory>
 #include "ExprAST.h"
@@ -23,5 +22,3 @@ public:
     const std::unique_ptr<StmtLstExprAST> &GetStmtList();
     const std::unique_ptr<PayloadExprAST> &GetPayload();
 };
-
-#endif //COMPILER_COMLINEBLOCKEXPRAST_H

--- a/compiler/cpp/src/parser/ast/CompStmtExprAST.h
+++ b/compiler/cpp/src/parser/ast/CompStmtExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 09.05.2021.
 //
 
-#ifndef COMPILER_COMPSTMTEXPRAST_H
-#define COMPILER_COMPSTMTEXPRAST_H
+#pragma once
 
 #include <memory>
 #include "KeyExprAST.h"
@@ -29,5 +28,3 @@ public:
     const std::unique_ptr<KeyExprAST> &GetKey();
     const std::unique_ptr<ValueExprAST> &GetValue();
 };
-
-#endif //COMPILER_COMPSTMTEXPRAST_H

--- a/compiler/cpp/src/parser/ast/ContentExprAST.h
+++ b/compiler/cpp/src/parser/ast/ContentExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 09.05.2021.
 //
 
-#ifndef COMPILER_CONTENTEXPRAST_H
-#define COMPILER_CONTENTEXPRAST_H
+#pragma once
 
 #include <vector>
 #include <memory>
@@ -20,5 +19,3 @@ public:
     explicit ContentExprAST(std::vector<std::unique_ptr<ExprAST>> sections): Sections(std::move(sections)) {}
     const std::vector<std::unique_ptr<ExprAST>> &GetSections();
 };
-
-#endif //COMPILER_CONTENTEXPRAST_H

--- a/compiler/cpp/src/parser/ast/ExprAST.h
+++ b/compiler/cpp/src/parser/ast/ExprAST.h
@@ -4,12 +4,9 @@
 // Created by Marc on 04.05.2021.
 //
 
-#ifndef COMPILER_EXPRAST_H
-#define COMPILER_EXPRAST_H
+#pragma once
 
 class ExprAST {
 public:
     virtual ~ExprAST() = default;
 };
-
-#endif //COMPILER_EXPRAST_H

--- a/compiler/cpp/src/parser/ast/HasStmtExprAST.h
+++ b/compiler/cpp/src/parser/ast/HasStmtExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 09.05.2021.
 //
 
-#ifndef COMPILER_HASSTMTEXPRAST_H
-#define COMPILER_HASSTMTEXPRAST_H
+#pragma once
 
 #include <memory>
 #include "KeyExprAST.h"
@@ -21,5 +20,3 @@ public:
     const std::unique_ptr<KeyExprAST> &GetKey();
     bool GetInverted() const;
 };
-
-#endif //COMPILER_HASSTMTEXPRAST_H

--- a/compiler/cpp/src/parser/ast/IdentifierExprAST.h
+++ b/compiler/cpp/src/parser/ast/IdentifierExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 04.05.2021.
 //
 
-#ifndef COMPILER_IDENTIFIEREXPRAST_H
-#define COMPILER_IDENTIFIEREXPRAST_H
+#pragma once
 
 #include <string>
 #include <utility>
@@ -21,5 +20,3 @@ public:
     std::string GetName() const;
     int GetIndex() const;
 };
-
-#endif //COMPILER_IDENTIFIEREXPRAST_H

--- a/compiler/cpp/src/parser/ast/IfBlockExprAST.h
+++ b/compiler/cpp/src/parser/ast/IfBlockExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 09.05.2021.
 //
 
-#ifndef COMPILER_IFBLOCKEXPRAST_H
-#define COMPILER_IFBLOCKEXPRAST_H
+#pragma once
 
 #include <memory>
 #include "StmtLstExprAST.h"
@@ -21,5 +20,3 @@ public:
     const std::unique_ptr<StmtLstExprAST> &GetStmtList();
     const std::unique_ptr<PayloadExprAST> &GetPayload();
 };
-
-#endif //COMPILER_IFBLOCKEXPRAST_H

--- a/compiler/cpp/src/parser/ast/KeyExprAST.h
+++ b/compiler/cpp/src/parser/ast/KeyExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 09.05.2021.
 //
 
-#ifndef COMPILER_KEYEXPRAST_H
-#define COMPILER_KEYEXPRAST_H
+#pragma once
 
 #include <vector>
 #include <memory>
@@ -18,5 +17,3 @@ public:
     explicit KeyExprAST(std::vector<std::unique_ptr<IdentifierExprAST>> stmts): Identifiers(std::move(stmts)) {}
     const std::vector<std::unique_ptr<IdentifierExprAST>> &GetIdentifiers();
 };
-
-#endif //COMPILER_KEYEXPRAST_H

--- a/compiler/cpp/src/parser/ast/NumberExprAST.h
+++ b/compiler/cpp/src/parser/ast/NumberExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 04.05.2021.
 //
 
-#ifndef COMPILER_NUMBEREXPRAST_H
-#define COMPILER_NUMBEREXPRAST_H
+#pragma once
 
 #include "ValueExprAST.h"
 
@@ -16,5 +15,3 @@ public:
     explicit NumberExprAST(int val): Value(val) {}
     int GetValue() const;
 };
-
-#endif //COMPILER_NUMBEREXPRAST_H

--- a/compiler/cpp/src/parser/ast/PayloadExprAST.h
+++ b/compiler/cpp/src/parser/ast/PayloadExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 09.05.2021.
 //
 
-#ifndef COMPILER_PAYLOADEXPRAST_H
-#define COMPILER_PAYLOADEXPRAST_H
+#pragma once
 
 #include <string>
 
@@ -16,5 +15,3 @@ public:
     explicit PayloadExprAST(std::string val): Value(std::move(val)) {}
     std::string GetValue() const;
 };
-
-#endif //COMPILER_PAYLOADEXPRAST_H

--- a/compiler/cpp/src/parser/ast/SectionExprAST.h
+++ b/compiler/cpp/src/parser/ast/SectionExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 09.05.2021.
 //
 
-#ifndef COMPILER_SECTIONEXPRAST_H
-#define COMPILER_SECTIONEXPRAST_H
+#pragma once
 
 #include <vector>
 #include <memory>
@@ -20,5 +19,3 @@ public:
             ComBlocks(std::move(comBlocks)) {}
     const std::vector<std::unique_ptr<ComBlockExprAST>> &GetComBlocks();
 };
-
-#endif //COMPILER_SECTIONEXPRAST_H

--- a/compiler/cpp/src/parser/ast/StmtExprAST.h
+++ b/compiler/cpp/src/parser/ast/StmtExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 09.05.2021.
 //
 
-#ifndef COMPILER_STMTEXPRAST_H
-#define COMPILER_STMTEXPRAST_H
+#pragma once
 
 #include <vector>
 #include "ExprAST.h"
@@ -14,5 +13,3 @@ class StmtExprAST: public ExprAST {
 public:
     ~StmtExprAST() override = default;
 };
-
-#endif //COMPILER_STMTEXPRAST_H

--- a/compiler/cpp/src/parser/ast/StmtLstExprAST.h
+++ b/compiler/cpp/src/parser/ast/StmtLstExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 09.05.2021.
 //
 
-#ifndef COMPILER_STMTLSTEXPRAST_H
-#define COMPILER_STMTLSTEXPRAST_H
+#pragma once
 
 #include <utility>
 #include <vector>
@@ -19,5 +18,3 @@ public:
     explicit StmtLstExprAST(std::vector<std::unique_ptr<StmtExprAST>> stmts): Stmts(std::move(stmts)) {}
     const std::vector<std::unique_ptr<StmtExprAST>> &GetStatements();
 };
-
-#endif //COMPILER_STMTLSTEXPRAST_H

--- a/compiler/cpp/src/parser/ast/StringExprAST.h
+++ b/compiler/cpp/src/parser/ast/StringExprAST.h
@@ -4,8 +4,7 @@
 // Created by Marc on 04.05.2021.
 //
 
-#ifndef COMPILER_STRINGEXPRAST_H
-#define COMPILER_STRINGEXPRAST_H
+#pragma once
 
 #include <string>
 #include <utility>
@@ -18,5 +17,3 @@ public:
     explicit StringExprAST(std::string val): Value(std::move(val)) {}
     std::string GetValue() const;
 };
-
-#endif //COMPILER_STRINGEXPRAST_H

--- a/compiler/cpp/src/parser/ast/ValueExprAST.h
+++ b/compiler/cpp/src/parser/ast/ValueExprAST.h
@@ -4,12 +4,9 @@
 // Created by Marc on 09.05.2021.
 //
 
-#ifndef COMPILER_VALUEEXPRAST_H
-#define COMPILER_VALUEEXPRAST_H
+#pragma once
 
 class ValueExprAST {
 public:
     virtual ~ValueExprAST() = default;
 };
-
-#endif //COMPILER_VALUEEXPRAST_H

--- a/compiler/cpp/src/parser/parser.cpp
+++ b/compiler/cpp/src/parser/parser.cpp
@@ -27,6 +27,12 @@ std::unique_ptr<NumberExprAST> parseNumber() {
     return std::make_unique<NumberExprAST>(value);
 }
 
+std::unique_ptr<BooleanExprAST> parseBoolean() {
+    bool value = stoi(CurTok.getValue());
+    getNextToken(); // Consume boolean literal
+    return std::make_unique<BooleanExprAST>(value);
+}
+
 std::unique_ptr<StringExprAST> parseString() {
     std::string value = CurTok.getValue();
     getNextToken(); // Consume string literal
@@ -34,7 +40,9 @@ std::unique_ptr<StringExprAST> parseString() {
 }
 
 std::unique_ptr<ValueExprAST> parseValue() {
-    if (CurTok.getType() == TOK_NUMBER) return parseNumber(); // Consume number
+    int type = CurTok.getType();
+    if (type == TOK_NUMBER) return parseNumber(); // Consume number
+    if (type == TOK_TRUE || type == TOK_FALSE) return parseBoolean(); // Consume boolean
     return parseString(); // Consume string
 }
 

--- a/compiler/cpp/src/parser/parser.cpp
+++ b/compiler/cpp/src/parser/parser.cpp
@@ -40,10 +40,17 @@ std::unique_ptr<StringExprAST> parseString() {
 }
 
 std::unique_ptr<ValueExprAST> parseValue() {
-    int type = CurTok.getType();
-    if (type == TOK_NUMBER) return parseNumber(); // Consume number
-    if (type == TOK_TRUE || type == TOK_FALSE) return parseBoolean(); // Consume boolean
-    return parseString(); // Consume string
+    switch (CurTok.getType()) {
+        case TOK_NUMBER:
+            return parseNumber(); // Consume number
+        case TOK_TRUE:
+        case TOK_FALSE:
+            return parseBoolean(); // Consume boolean
+        case TOK_STRING:
+            return parseString(); // Consume string
+        default:
+            throw std::runtime_error("Invalid token. Expected number, boolean or string at " + CurTok.getCodePos() + " got" + std::to_string(CurTok.getType()));
+    }
 }
 
 std::unique_ptr<IdentifierExprAST> parseIdentifier() {

--- a/compiler/cpp/src/parser/parser.cpp
+++ b/compiler/cpp/src/parser/parser.cpp
@@ -28,7 +28,7 @@ std::unique_ptr<NumberExprAST> parseNumber() {
 }
 
 std::unique_ptr<BooleanExprAST> parseBoolean() {
-    bool value = stoi(CurTok.getValue());
+    bool value = CurTok.getValue() == "true";
     getNextToken(); // Consume boolean literal
     return std::make_unique<BooleanExprAST>(value);
 }

--- a/compiler/cpp/src/parser/parser.h
+++ b/compiler/cpp/src/parser/parser.h
@@ -4,8 +4,7 @@
 // Created by Marc on 02.05.2021.
 //
 
-#ifndef COMPILER_PARSER_H
-#define COMPILER_PARSER_H
+#pragma once
 
 #include <string>
 #include <iostream>
@@ -52,5 +51,3 @@ std::unique_ptr<ComBlockBlockExprAST> parseComBlockBlock();
 std::unique_ptr<ComLineBlockExprAST> parseComLineBlock();
 std::unique_ptr<SectionExprAST> parseSection();
 std::unique_ptr<ContentExprAST> parseContent();
-
-#endif //COMPILER_PARSER_H

--- a/compiler/cpp/src/parser/parser.h
+++ b/compiler/cpp/src/parser/parser.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include "ast/ArbitraryExprAST.h"
 #include "ast/NumberExprAST.h"
+#include "ast/BooleanExprAST.h"
 #include "ast/StringExprAST.h"
 #include "ast/IdentifierExprAST.h"
 #include "ast/StmtExprAST.h"
@@ -36,6 +37,7 @@ ExprAST* executeSyntaxAnalysis(bool isSingleStatement, const std::string &fileIn
 
 std::unique_ptr<ArbitraryExprAST> parseArbitrary();
 std::unique_ptr<NumberExprAST> parseNumber();
+std::unique_ptr<BooleanExprAST> parseBoolean();
 std::unique_ptr<StringExprAST> parseString();
 std::unique_ptr<ValueExprAST> parseValue();
 std::unique_ptr<IdentifierExprAST> parseIdentifier();

--- a/media/test-file.yml
+++ b/media/test-file.yml
@@ -2,7 +2,7 @@ build: ${{SPRING_MAVEN_SOURCE_DIRECTORY}}
 container_name: ${{PROJECT_NAME_CONTAINER}}-backend-spring-maven
 restart: always
 networks:
-#? if has service.frontend[1].name {
+#? if service.frontend[1].preselected == false {
 #  - frontend-backend
 #? }
 #? if has service.database {


### PR DESCRIPTION
As we previously already had support in the lexer for this, we now fully supporting boolean comparison.

Now, something like this is possible:

**Work data:**
```json
{
    "service": {
        "frontend": [
            {
                "label": "Spring Maven",
                "preselected": false
            },
            {
                "label": "Spring Gradle",
                "preselected": true
            }
        ]
    }
}
```

**Input file:**
```yaml
#? if service.frontend[1].preselected == false {
#  - frontend-backend
#? }
```

In this example, the result would be `false` and the comment would not be uncommented.