### PR TITLE
Add compiler flag to switch compilers

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -38,6 +38,12 @@ func main() {
 				Usage:   "Specifies the closing block comment character(s) of your data format",
 			},
 			&cli.StringFlag{
+				Name:        "compiler",
+				Aliases:     []string{"c"},
+				DefaultText: "cpp",
+				Usage:       "CCom supports several compiler implementations, which you can choose from. Possible options are: 'cpp' (default), 'java', more to come ...",
+			},
+			&cli.StringFlag{
 				Name:        "data",
 				Aliases:     []string{"d"},
 				DefaultText: "{}",
@@ -78,6 +84,7 @@ func main() {
 		Action: func(c *cli.Context) error {
 			processInput(
 				c.Args().Get(0),
+				c.String("compiler"),
 				c.String("block-comment-chars-open"),
 				c.String("block-comment-chars-close"),
 				c.String("data"),

--- a/cli/preprocessor.go
+++ b/cli/preprocessor.go
@@ -12,6 +12,7 @@ import (
 
 func processInput(
 	fileInput string,
+	compiler string,
 	blockCommentCharsOpen string,
 	blockCommentCharsClose string,
 	dataInput string,
@@ -26,7 +27,7 @@ func processInput(
 	if !silentFlag {
 		fmt.Print("Analyzing inputs ... ")
 	}
-	analyze(&fileInput, &dataInput, lang, &lineCommentChars, &blockCommentCharsOpen, &blockCommentCharsClose, modeSingle)
+	analyze(&fileInput, &dataInput, &compiler, lang, &lineCommentChars, &blockCommentCharsOpen, &blockCommentCharsClose, modeSingle)
 	if !silentFlag {
 		fmt.Println("done")
 	}
@@ -35,7 +36,17 @@ func processInput(
 	if !silentFlag {
 		fmt.Print("Compiling ... ")
 	}
-	result := util.ExecuteAndWaitWithOutput("./ccomc", strconv.FormatBool(modeSingle), fileInput, dataInput, lineCommentChars, blockCommentCharsOpen, blockCommentCharsClose)
+
+	var result string
+	switch compiler {
+	case "cpp", "c++":
+		result = util.ExecuteAndWaitWithOutput("./ccomc", strconv.FormatBool(modeSingle), fileInput, dataInput, lineCommentChars, blockCommentCharsOpen, blockCommentCharsClose)
+	case "java":
+		result = util.ExecuteAndWaitWithOutput("./ccomc-java.jar", strconv.FormatBool(modeSingle), fileInput, dataInput, lineCommentChars, blockCommentCharsOpen, blockCommentCharsClose)
+	default:
+		log.Fatal("Invalid compiler name. Only 'cpp' and 'java' are allowed values.")
+	}
+
 	if !silentFlag {
 		fmt.Println("done")
 	}
@@ -62,6 +73,7 @@ func processInput(
 func analyze(
 	fileInput *string,
 	dataInput *string,
+	compiler *string,
 	lang string,
 	lineCommentChars *string,
 	blockCommentCharsOpen *string,
@@ -71,6 +83,9 @@ func analyze(
 	// Ensure value of input data
 	if *dataInput == "" {
 		*dataInput = "{}"
+	}
+	if *compiler == "" {
+		*compiler = "cpp"
 	}
 	if lang != "" {
 		*lineCommentChars, *blockCommentCharsOpen, *blockCommentCharsClose = getCommentCharsFromLang(lang)


### PR DESCRIPTION
Added the cli flag `--compiler` / `-c` to switch between the default C++ and the new Java implementation.

Valid values are:
- `cpp` / `c++` (default) --> CLI calls `ccomc` on Linux / `ccomc.exe` on Windows
- `java` --> CLI calls `ccomc-java.jar`